### PR TITLE
Added parameters to hide download button, print button and the menu itself.

### DIFF
--- a/Gotho.BlazorPdf.Docs/Code/HidingElements.cs
+++ b/Gotho.BlazorPdf.Docs/Code/HidingElements.cs
@@ -1,0 +1,22 @@
+namespace Gotho.BlazorPdf.Docs.Code;
+
+public static class HidingElements
+{
+    public static string Config =>
+@"
+@* Fully hide the menu *@
+<PdfViewer HideThumbnails=""false""
+		   SinglePageMode=""false""
+		   Height=""100vh""
+		   Url=""https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf""
+		   HideMenu=""true"" />
+
+@* Or hide the download or print buttons *@
+<PdfViewer HideThumbnails=""false""
+		   SinglePageMode=""false""
+		   Height=""100vh""
+		   Url=""https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf""
+		   HideDownloadButton=""true""
+		   HidePrintButton=""true"" />
+";
+}

--- a/Gotho.BlazorPdf.Docs/Components/DocsMenu.razor
+++ b/Gotho.BlazorPdf.Docs/Components/DocsMenu.razor
@@ -9,6 +9,7 @@
         <MudNavGroup Title="Configuration" Expanded="true">
             <MudNavLink Href="/docs/configuration/labels">Labels</MudNavLink>
             <MudNavLink Href="/docs/configuration/colours">Colours</MudNavLink>
+            <MudNavLink Href="/docs/configuration/hidingelements">Hiding elements</MudNavLink>
         </MudNavGroup>
         <MudNavLink Href="/docs/orientation">Orientation</MudNavLink>
         <MudNavLink Href="/docs/scroll">Scroll Mode</MudNavLink>

--- a/Gotho.BlazorPdf.Docs/Components/Pages/Documentation/ConfigurationHidingElements.razor
+++ b/Gotho.BlazorPdf.Docs/Components/Pages/Documentation/ConfigurationHidingElements.razor
@@ -1,0 +1,37 @@
+@page "/docs/configuration/hidingelements"
+@using Gotho.BlazorPdf.Config
+
+<PageTitle>Blazor PDF | Hiding elements</PageTitle>
+
+<PageMetadata Title="Blazor PDF | Hiding elements"
+			  Description="The visibility of the print and download buttons, as well as the menu itself, can be adjusted."
+			  Url="https://blazorpdf.info/docs/configuration/labels" />
+
+<div style="max-width: 1440px; margin: 3em auto auto;">
+
+	<MudGrid>
+		<MudItem sm="3">
+			<DocsMenu />
+		</MudItem>
+		<MudItem sm="9" Style="overflow: auto" Class="mb-5">
+			<MudText Typo="Typo.h2" Class="mb-5">Configuration | Hiding elements</MudText>
+			<MudText Class="mb-5">
+				The visibility of the print and download buttons, as well as the menu itself, can be adjusted.
+				This can be done by passing the right parameter to your PDF viewer
+			</MudText>
+
+			<CodeSnippet Body="@HidingElements.Config" Lang="csharp" />
+
+			<PdfViewer Url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf" />
+
+			@* <PdfViewer LocalizedStrings="FinnishStrings"
+					   Url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"
+					   HideMenu ="true"/> *@
+
+		</MudItem>
+	</MudGrid>
+</div>
+
+@code {
+
+}

--- a/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
+++ b/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
@@ -65,30 +65,39 @@
                                aria-label="@LocalizedStrings.ZoomIn"/>
             </MudTooltip>
             <MudSpacer/>
-            <MudMenu Icon="@Icons.Menu" Color="MudColors.IconColor">
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.RotateClockwise"
-                             Label="@LocalizedStrings.RotateClockwise" OnClick="RotateClockwiseAsync"/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.RotateCounterclockwise"
-                             Label="@LocalizedStrings.RotateCounterclockwise" OnClick="RotateCounterclockwiseAsync"/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.SwitchOrientation"
-                             Label="@LocalizedStrings.SwitchOrientation" OnClick="SwitchOrientationAsync"/>
-                <MudDivider/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.FirstPage" Label="@LocalizedStrings.FirstPage"
-                             OnClick="FirstPageAsync"/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.LastPage" Label="@LocalizedStrings.LastPage"
-                             OnClick="LastPageAsync"/>
-                <MudDivider/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.ResetZoom" Label="@LocalizedStrings.ResetZoom"
-                             OnClick="ResetZoomAsync"/>
-                <MudDivider/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.PrintDocument"
-                             Label="@LocalizedStrings.PrintDocument" OnClick="PrintDocumentAsync"/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.DownloadDocument"
-                             Label="@LocalizedStrings.DownloadDocument" OnClick="DownloadDocumentAsync"/>
-                <MudDivider/>
-                <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.Draw" Label="@LocalizedStrings.Draw"
-                             OnClick="ToggleDrawingAsync"/>
-            </MudMenu>
+            @if (!HideMenu)
+            {
+                <MudMenu Icon="@Icons.Menu" Color="MudColors.IconColor">
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.RotateClockwise"
+                                 Label="@LocalizedStrings.RotateClockwise" OnClick="RotateClockwiseAsync" />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.RotateCounterclockwise"
+                                 Label="@LocalizedStrings.RotateCounterclockwise" OnClick="RotateCounterclockwiseAsync" />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.SwitchOrientation"
+                                 Label="@LocalizedStrings.SwitchOrientation" OnClick="SwitchOrientationAsync" />
+                    <MudDivider />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.FirstPage" Label="@LocalizedStrings.FirstPage"
+                                 OnClick="FirstPageAsync" />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.LastPage" Label="@LocalizedStrings.LastPage"
+                                 OnClick="LastPageAsync" />
+                    <MudDivider />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.ResetZoom" Label="@LocalizedStrings.ResetZoom"
+                                 OnClick="ResetZoomAsync" />
+                    <MudDivider />
+                    @if (!HidePrintButton)
+                    {
+                        <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.PrintDocument"
+                                     Label="@LocalizedStrings.PrintDocument" OnClick="PrintDocumentAsync" />
+                    }
+                    @if (!HideDownloadButton)
+                    {
+                        <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.DownloadDocument"
+                                     Label="@LocalizedStrings.DownloadDocument" OnClick="DownloadDocumentAsync" />
+                    }
+                    <MudDivider />
+                    <MudMenuItem IconColor="MudColors.IconColor" Icon="@Icons.Draw" Label="@LocalizedStrings.Draw"
+                                 OnClick="ToggleDrawingAsync" />
+                </MudMenu>
+            }
         </MudToolBar>
         @if (Loading)
         {

--- a/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor.cs
+++ b/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor.cs
@@ -7,4 +7,31 @@ public partial class MudPdfViewer : PdfViewer
 {
     [Parameter] public MudPdfIconConfig Icons { get; set; } = new();
     [Parameter] public MudPdfColorConfig MudColors { get; set; } = new();
+
+    /// <summary>
+    /// Hides the print button
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HidePrintButton { get; set; } = false;
+
+    /// <summary>
+    /// Hides the download button
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HideDownloadButton { get; set; } = false;
+
+    /// <summary>
+    /// Hides the menu completely
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HideMenu { get; set; } = false;
 }

--- a/Gotho.BlazorPdf/Gotho.BlazorPdf.csproj
+++ b/Gotho.BlazorPdf/Gotho.BlazorPdf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
         <PackageId>Gotho.BlazorPdf</PackageId>
@@ -20,10 +20,10 @@
         <RootNamespace>Gotho.BlazorPdf</RootNamespace>
     </PropertyGroup>
 
-    <Target Name="CompileTypeScript" BeforeTargets="Build">
-        <Exec Command="npm run ts" />
-    </Target>
-
+	<Target Name="CompileTypeScript" BeforeTargets="Build">
+		<Exec Command="npm run ts" />
+	</Target>
+	
     <Target Name="MinifyJavaScript" BeforeTargets="Build" AfterTargets="CompileTypeScript">
         <Exec Command="npm run ts-min" />
     </Target>

--- a/Gotho.BlazorPdf/PdfViewer.razor
+++ b/Gotho.BlazorPdf/PdfViewer.razor
@@ -84,96 +84,104 @@
         <div class="blazorpdf-toolbar__spacer"></div>
 
         @*Menu*@
-        <div class="blazorpdf-toolbar__item">
-            <div class="blazorpdf-toolbar__menu-wrapper">
-                <input type="checkbox" id="menu-toggle" hidden>
-                <label for="menu-toggle" class="blazorpdf-toolbar__menu-trigger-button">
-                    <span>
-                        <MenuIcon Color="@Colors.Icon"/>
-                    </span>
-                </label>
-                <div class="blazorpdf-toolbar__menu">
-                    <label for="menu-toggle" class="blazorpdf-toolbar__menu-overlay"></label>
-                    <div class="blazorpdf-toolbar__menu-content">
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="RotateClockwiseAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <RotateCWIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span
-                                class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.RotateClockwise</span>
-                        </button>
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="RotateCounterclockwiseAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <RotateCCWIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span
-                                class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.RotateCounterclockwise</span>
-                        </button>
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="SwitchOrientationAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <SwitchOrientationIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span
-                                class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.SwitchOrientation</span>
-                        </button>
-                        <hr class="blazorpdf-toolbar__menu-divider">
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="FirstPageAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <FirstPageIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.FirstPage</span>
-                        </button>
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="LastPageAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <LastPageIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.LastPage</span>
-                        </button>
-                        <hr class="blazorpdf-toolbar__menu-divider">
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="ResetZoomAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <ZoomResetIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.ResetZoom</span>
-                        </button>
-                        <hr class="blazorpdf-toolbar__menu-divider">
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="PrintDocumentAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <PrintIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.PrintDocument</span>
-                        </button>
-                        <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                @onclick="DownloadDocumentAsync">
-                            <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                <DownloadIcon Color="@Colors.Icon"/>
-                            </span>
-                            <span
-                                class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.DownloadDocument</span>
-                        </button>
-                        @if (SinglePageMode)
-                        {
+        @if (!HideMenu)
+        {
+            <div class="blazorpdf-toolbar__item">
+                <div class="blazorpdf-toolbar__menu-wrapper">
+                    <input type="checkbox" id="menu-toggle" hidden>
+                    <label for="menu-toggle" class="blazorpdf-toolbar__menu-trigger-button">
+                        <span>
+                            <MenuIcon Color="@Colors.Icon" />
+                        </span>
+                    </label>
+                    <div class="blazorpdf-toolbar__menu">
+                        <label for="menu-toggle" class="blazorpdf-toolbar__menu-overlay"></label>
+                        <div class="blazorpdf-toolbar__menu-content">
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="RotateClockwiseAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <RotateCWIcon Color="@Colors.Icon" />
+                                </span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.RotateClockwise</span>
+                            </button>
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="RotateCounterclockwiseAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <RotateCCWIcon Color="@Colors.Icon" />
+                                </span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.RotateCounterclockwise</span>
+                            </button>
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="SwitchOrientationAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <SwitchOrientationIcon Color="@Colors.Icon" />
+                                </span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.SwitchOrientation</span>
+                            </button>
                             <hr class="blazorpdf-toolbar__menu-divider">
                             <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
-                                    @onclick="ToggleDrawingAsync">
+                                    @onclick="FirstPageAsync">
                                 <span class="blazorpdf-toolbar__menu-menu-item-icon">
-                                    <DrawIcon Color="@Colors.Icon"/>
+                                    <FirstPageIcon Color="@Colors.Icon" />
                                 </span>
-                                <span
-                                    class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.Draw</span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.FirstPage</span>
                             </button>
-                        }
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="LastPageAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <LastPageIcon Color="@Colors.Icon" />
+                                </span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.LastPage</span>
+                            </button>
+                            <hr class="blazorpdf-toolbar__menu-divider">
+                            <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                    @onclick="ResetZoomAsync">
+                                <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                    <ZoomResetIcon Color="@Colors.Icon" />
+                                </span>
+                                <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.ResetZoom</span>
+                            </button>
+                            <hr class="blazorpdf-toolbar__menu-divider">
+                            @if (!HidePrintButton)
+                            {
+                                <button type="button"
+                                        class="blazorpdf-toolbar__menu-menu-item"
+                                        disabled="@InputDisabled()"
+                                        @onclick="PrintDocumentAsync">
+                                    <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                        <PrintIcon Color="@Colors.Icon" />
+                                    </span>
+                                    <span class="blazorpdf-toolbar__menu-menu-item-text">
+                                        @LocalizedStrings.PrintDocument
+                                    </span>
+                                </button>
+                            }
+                            @if (!HideDownloadButton)
+                            {
+                                <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                        @onclick="DownloadDocumentAsync">
+                                    <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                        <DownloadIcon Color="@Colors.Icon" />
+                                    </span>
+                                    <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.DownloadDocument</span>
+                                </button>
+                            }
+                            @if (SinglePageMode)
+                            {
+                                <hr class="blazorpdf-toolbar__menu-divider">
+                                <button type="button" class="blazorpdf-toolbar__menu-menu-item" disabled="@InputDisabled()"
+                                        @onclick="ToggleDrawingAsync">
+                                    <span class="blazorpdf-toolbar__menu-menu-item-icon">
+                                        <DrawIcon Color="@Colors.Icon" />
+                                    </span>
+                                    <span class="blazorpdf-toolbar__menu-menu-item-text">@LocalizedStrings.Draw</span>
+                                </button>
+                            }
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        }
 
     </div>
 

--- a/Gotho.BlazorPdf/PdfViewer.razor.cs
+++ b/Gotho.BlazorPdf/PdfViewer.razor.cs
@@ -83,6 +83,33 @@ public partial class PdfViewer : ComponentBase
     [Parameter]
     public BlazorPdfColors Colors { get; set; } = new();
 
+    /// <summary>
+    /// Hides the print button
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HidePrintButton { get; set; } = false;
+
+    /// <summary>
+    /// Hides the download button
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HideDownloadButton { get; set; } = false;
+
+    /// <summary>
+    /// Hides the menu completely
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>
+    /// </remarks>
+    [Parameter]
+    public bool HideMenu { get; set; } = false;
+
     [Inject] private PdfInterop PdfInterop { get; set; } = default!;
     [Inject] protected BlazorPdfConfig Config { get; set; } = default!;
 


### PR DESCRIPTION
I needed the ability to hide certain buttons in the UI, but none of the PDF viewers give it out of the box (pdf-js doesn't let you do so OOTB as well).  
So, I decided to add parameters to the BlazorPdf viewer to hide some of the buttons.  

I don't feel like there is a need to hide other buttons than the download and print, so this commit adds the parameters to hide:

- Download button  
- Print button  
- 3-dot menu itself  

```razor
@* Fully hide the menu *@
<PdfViewer HideThumbnails="false"
           SinglePageMode="false"
           Height="100vh"
           Url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"
           HideMenu="true" />

@* Or hide the download or print buttons *@
<PdfViewer HideThumbnails="false"
           SinglePageMode="false"
           Height="100vh"
           Url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"
           HideDownloadButton="true"
           HidePrintButton="true" />
```