### PR TITLE
feat: make MudPdfViewer input variants configurable.

### DIFF
--- a/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
+++ b/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor
@@ -46,7 +46,7 @@
                         <MudNumericField
                             T="int"
                             Value="@PdfFile.Paging.CurrentPage"
-                            Variant="Variant.Filled"
+                            Variant="@PageFieldVariant"
                             Margin="Margin.Dense"
                             HideSpinButtons="true"
                             Disabled="InputDisabled()"
@@ -178,7 +178,7 @@
                                         Label="Find in Document"
                                         DebounceInterval="5"
                                         Placeholder="Query..."
-                                        Variant="Variant.Filled"/>
+                                        Variant="@SearchFieldVariant"/>
                                     <MudIconButton
                                         Icon="@(global::MudBlazor.Icons.Material.Filled.ChevronLeft)"
                                         Variant="Variant.Outlined"
@@ -272,7 +272,7 @@
                                     <MudTextField @bind-Value="PdfPassword" InputType="_passwordInputType"
                                                   Adornment="Adornment.End" AdornmentIcon="@_passwordInputIcon"
                                                   OnAdornmentClick="PeekPassword" Label="Password"
-                                                  Variant="Variant.Filled"
+                                                  Variant="@PasswordFieldVariant"
                                                   HelperText="Please enter the password for the PDF document."></MudTextField>
                                     @if (!string.IsNullOrEmpty(Error?.Message))
                                     {

--- a/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor.cs
+++ b/Gotho.BlazorPdf.MudBlazor/MudPdfViewer.razor.cs
@@ -1,5 +1,6 @@
 using Gotho.BlazorPdf.MudBlazor.Config;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace Gotho.BlazorPdf.MudBlazor;
 
@@ -7,4 +8,7 @@ public partial class MudPdfViewer : PdfViewer
 {
     [Parameter] public MudPdfIconConfig Icons { get; set; } = new();
     [Parameter] public MudPdfColorConfig MudColors { get; set; } = new();
+    [Parameter] public Variant PageFieldVariant { get; set; } = Variant.Filled;
+    [Parameter] public Variant PasswordFieldVariant { get; set; } = Variant.Filled;
+    [Parameter] public Variant SearchFieldVariant { get; set; } = Variant.Filled;
 }

--- a/Gotho.BlazorPdf.MudBlazor/package-lock.json
+++ b/Gotho.BlazorPdf.MudBlazor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gotho.blazorpdf.mudblazor",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gotho.blazorpdf.mudblazor",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "clean-css-cli": "^5.6.3"

--- a/Gotho.BlazorPdf.Tests.Mud/Components/Pages/InputVariants.razor
+++ b/Gotho.BlazorPdf.Tests.Mud/Components/Pages/InputVariants.razor
@@ -1,0 +1,28 @@
+﻿@page "/input-variants"
+@using Gotho.BlazorPdf.Tests.Server.Data
+@using global::MudBlazor
+
+<PageTitle>Input Variants</PageTitle>
+
+<MudStack Spacing="8">
+    <MudSelect @bind-Value="@_selectedVariant"
+               Label="Page / Password / Search Field Variant" FitContent Variant="Variant.Outlined">
+        <MudSelectItem Value="Variant.Text">Variant.Text</MudSelectItem>
+        <MudSelectItem Value="Variant.Outlined">Variant.Outlined</MudSelectItem>
+        <MudSelectItem Value="Variant.Filled">Variant.Filled</MudSelectItem>
+    </MudSelect>
+    <MudDivider />
+    <div>
+        <MudText GutterBottom Typo="Typo.subtitle2">Password Field</MudText>
+        <MudPdfViewer PasswordFieldVariant="@_selectedVariant" PageFieldVariant="@_selectedVariant" Url="https://raw.githubusercontent.com/tgothorp/MudBlazor.PdfViewer/refs/heads/main/files/test_pdf_document-protected.pdf" />
+    </div>
+    <MudDivider />
+    <div>
+        <MudText GutterBottom Typo="Typo.subtitle2">Current Page Field</MudText>
+        <MudPdfViewer PageFieldVariant="@_selectedVariant" SearchFieldVariant="@_selectedVariant" Url="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf" />
+    </div>
+</MudStack>
+
+@code {
+    private Variant _selectedVariant { get; set; } = Variant.Filled;
+}

--- a/Gotho.BlazorPdf.sln
+++ b/Gotho.BlazorPdf.sln
@@ -1,5 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88 stable
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gotho.BlazorPdf", "Gotho.BlazorPdf\Gotho.BlazorPdf.csproj", "{D212443C-E455-431B-A259-9B48C2CE23A4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gotho.BlazorPdf.Docs", "Gotho.BlazorPdf.Docs\Gotho.BlazorPdf.Docs.csproj", "{871A6502-3876-4B73-B072-60711EAD525D}"
@@ -40,6 +43,9 @@ Global
 		{9938825A-702C-42FD-A2B9-037326BC3C95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9938825A-702C-42FD-A2B9-037326BC3C95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9938825A-702C-42FD-A2B9-037326BC3C95}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{871A6502-3876-4B73-B072-60711EAD525D} = {66B7FF4B-BF29-4B24-87FE-788A1A5BA591}

--- a/Gotho.BlazorPdf/package-lock.json
+++ b/Gotho.BlazorPdf/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gotho.blazorpdf",
-  "version": "3.0.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gotho.blazorpdf",
-      "version": "3.0.1",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/blazor__javascript-interop": "^3.1.7",


### PR DESCRIPTION
### What this PR is changing:
Adds some new parameters to `MudPdfViewer.razor`. They allow developers to change the `Variant` of following input fields:
* `MudNumericField` used for the current page input
* `MudTextField` used for the search field
* `MudTextField` used for the password field when a pdf is protected

### Why is this needed?
Previously, the variant was hardcoded, which prevented developers from matching the PDF viewer's styling with the rest of their application's UI design. The default variant "Variant.Filled" looked a bit off in the current page input.

### Notes for the Reviewer:
* The default value is set to `global::MudBlazor.Variant.Filled` to ensure backwards compatibility / keep the defaults.
* Used `global::` alias to avoid namespace collisions inside the `Gotho.BlazorPdf.Mud` project.